### PR TITLE
Fix scaling in apply_sadeh.R

### DIFF
--- a/R/apply_sadeh.R
+++ b/R/apply_sadeh.R
@@ -104,7 +104,7 @@ apply_sadeh_ <- function(data) {
 
   data %>%
     mutate(
-      count = pmin(.data$axis1, 300),
+      count = pmin(.data$axis1 / 100, 300),
       sleep = (
         7.601
         - 0.065 * roll_avg(.data$count)


### PR DESCRIPTION
Actigraph counts need to be scaled by 100 before scoring with Sadeh (the same as in Cole-Kripke). See the Actigraph user manual: "He [Sadeh] used the same device that Cole-Kripke used to develop their algorithm, and ActiGraph therefore adapted it in
the same way by scaling our data".