### PR TITLE
Prepare for first CRAN submission (0.3.0)

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,5 @@ actigraph\.bib$
 ^\.github$
 ^\.positai$
 ^\.claude$
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ src/*.gcno
 src/*.o.tmp
 .positai
 .claude
+/doc/
+/Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: actigraph.sleepr
 Type: Package
 Title: Detect Periods of Sleep and Non-Wear from 'ActiGraph' Data
-Version: 0.2.0
+Version: 0.3.0
 Authors@R: c(person(given = "Desislava",
            family = "Petkova",
            email = "desislavka@gmail.com",
@@ -21,7 +21,6 @@ BugReports: https://github.com/dipetkov/actigraph.sleepr/issues
 License: GPL (>= 2)
 Encoding: UTF-8
 LazyData: true
-NeedsCompilation: no
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
 Depends:
@@ -41,13 +40,12 @@ Imports:
     magrittr,
     tibble,
     tidyselect
-Suggests: 
+Suggests:
     covr,
     knitr,
     readr,
     rmarkdown,
     testthat,
-    tools,
     lintr
 VignetteBuilder: knitr
 LinkingTo: Rcpp

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ License: GPL (>= 2)
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 8.0.0
 Depends:
     R (>= 3.2.4)
 Imports:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# actigraph.sleepr 0.3.0
+
+* First CRAN submission.
+* Read `*.agd` files directly via `DBI` and `RSQLite`, removing the
+  dependency on `dbplyr` (#16, @muschellij2).
+
 # actigraph.sleepr 0.2.0
 
 * Fixes bugs and updates to `dplyr` and `tidyr`.

--- a/R/read_agd.R
+++ b/R/read_agd.R
@@ -9,8 +9,9 @@
 #' include axis2, axis2, steps, lux and inclinometer indicators
 #' (incline off, standing, sitting and lying). The device settings
 #' are stored as attributes, which include `epochlength`.
-#' @references The AGD file format is described in the ActiLife 6 Manual.
-#' <https://actigraphcorp.com/support/manuals/actilife-6-manual/>
+#' @references The AGD file format is described in the ActiLife 6 User's
+#' Manual by the ActiGraph Software Department, 04/03/2012
+#' (Document SFT12DOC13, Revision A).
 #' @seealso [read_agd_raw()]
 #' @examples
 #' file <- system.file("extdata", "GT3XPlus-RawData-Day01.agd",
@@ -80,7 +81,7 @@ read_agd <- function(file, tz = "UTC") {
 #' monitor removal when worn against the skin. If that data is
 #' available, the return list includes a capsense table as well.
 #' @references ActiLife 6 User's Manual by the ActiGraph Software
-#' Department. 04/03/2012.
+#' Department, 04/03/2012 (Document SFT12DOC13, Revision A).
 #' @references `covertagd`: R package for converting agd files
 #' from ActiGraph into data.frames.
 #' @seealso [read_agd()]

--- a/README.Rmd
+++ b/README.Rmd
@@ -18,7 +18,7 @@ rvers <- gsub(".*(\\d+.\\d+.\\d+).*", "\\1", rm)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![R-CMD-check](https://github.com/dipetkov/actigraph.sleepr/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/dipetkov/actigraph.sleepr/actions/workflows/R-CMD-check.yaml)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/dipetkov/actigraph.sleepr?branch=master&svg=true)](https://ci.appveyor.com/project/dipetkov/actigraph.sleepr)
-[![codecov](https://codecov.io/gh/dipetkov/actigraph.sleepr/branch/master/graph/badge.svg)](https://codecov.io/gh/dipetkov/actigraph.sleepr)
+[![codecov](https://codecov.io/gh/dipetkov/actigraph.sleepr/branch/master/graph/badge.svg)](https://app.codecov.io/gh/dipetkov/actigraph.sleepr)
 <!-- badges: end -->
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
@@ -44,7 +44,7 @@ remotes::install_github("dipetkov/actigraph.sleepr")
 
 ### Read AGD file(s)
 
-An AGD file is an SQLite database file exported by an ActiGraph device. See the [ActiLife 6 User manual](https://www.actigraphcorp.com/support/manuals/actilife-6-manual/). For illustration let's use one day of sample data recorded by a GT3X+ monitor.
+An AGD file is an SQLite database file exported by an ActiGraph device. See the ActiLife 6 User's Manual by the ActiGraph Software Department, 04/03/2012 (Document SFT12DOC13, Revision A). For illustration let's use one day of sample data recorded by a GT3X+ monitor.
 
 ```{r }
 library("actigraph.sleepr")

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.re
 [![R-CMD-check](https://github.com/dipetkov/actigraph.sleepr/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/dipetkov/actigraph.sleepr/actions/workflows/R-CMD-check.yaml)
 [![AppVeyor Build
 Status](https://ci.appveyor.com/api/projects/status/github/dipetkov/actigraph.sleepr?branch=master&svg=true)](https://ci.appveyor.com/project/dipetkov/actigraph.sleepr)
-[![codecov](https://codecov.io/gh/dipetkov/actigraph.sleepr/branch/master/graph/badge.svg)](https://codecov.io/gh/dipetkov/actigraph.sleepr)
+[![codecov](https://codecov.io/gh/dipetkov/actigraph.sleepr/branch/master/graph/badge.svg)](https://app.codecov.io/gh/dipetkov/actigraph.sleepr)
 <!-- badges: end -->
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
@@ -14,10 +14,10 @@ Status](https://ci.appveyor.com/api/projects/status/github/dipetkov/actigraph.sl
 ### `actigraph.sleepr`: Sleep and non-wear detection from ActiGraph data
 
 The `actigraph.sleepr` package implements three sleep scoring/detection
-algorithms: Sadeh (Sadeh, Sharkey, and Carskadon 1994), Cole-Kripke
-(Cole et al. 1992) and Tudor-Locke (Tudor-Locke et al. 2014) as well as
-two non-wear detection algorithms: Troiano (Troiano et al. 2008) and
-Choi (Choi et al. 2011).
+algorithms: Sadeh (Sadeh et al. 1994), Cole-Kripke (Cole et al. 1992)
+and Tudor-Locke (Tudor-Locke et al. 2014) as well as two non-wear
+detection algorithms: Troiano (Troiano et al. 2008) and Choi (Choi et
+al. 2011).
 
 ### Installation
 
@@ -29,10 +29,9 @@ remotes::install_github("dipetkov/actigraph.sleepr")
 ### Read AGD file(s)
 
 An AGD file is an SQLite database file exported by an ActiGraph device.
-See the [ActiLife 6 User
-manual](https://www.actigraphcorp.com/support/manuals/actilife-6-manual/).
-For illustration let’s use one day of sample data recorded by a GT3X+
-monitor.
+See the ActiLife 6 User’s Manual by the ActiGraph Software Department,
+04/03/2012 (Document SFT12DOC13, Revision A). For illustration let’s use
+one day of sample data recorded by a GT3X+ monitor.
 
 ``` r
 library("actigraph.sleepr")
@@ -40,6 +39,20 @@ file_10s <- system.file("extdata", "GT3XPlus-RawData-Day01.agd",
   package = "actigraph.sleepr"
 )
 agdb_10s <- read_agd(file_10s)
+#> Warning: There was 1 warning in `mutate()`.
+#> ℹ In argument: `across(matches("dateOfBirth"), ticks_to_dttm, tz = tz)`.
+#> Caused by warning:
+#> ! The `...` argument of `across()` is deprecated as of dplyr 1.1.0.
+#> Supply arguments directly to `.fns` through an anonymous function instead.
+#>
+#>   # Previously
+#>   across(a:b, mean, na.rm = TRUE)
+#>
+#>   # Now
+#>   across(a:b, \(x) mean(x, na.rm = TRUE))
+#> ℹ The deprecated feature was likely used in the actigraph.sleepr package.
+#>   Please report the issue at
+#>   <https://github.com/dipetkov/actigraph.sleepr/issues>.
 ```
 
 The `read_agd` function loads the raw activity measurements into a
@@ -99,6 +112,14 @@ that fall into the same 60s epoch.
 ``` r
 # Collapse epochs from 10 sec to 60 sec by summing
 agdb_60s <- agdb_10s %>% collapse_epochs(60)
+#> Warning: `when()` was deprecated in purrr 1.0.0.
+#> ℹ Please use `if` instead.
+#> ℹ The deprecated feature was likely used in the actigraph.sleepr package.
+#>   Please report the issue at
+#>   <https://github.com/dipetkov/actigraph.sleepr/issues>.
+#> This warning is displayed once per session.
+#> Call `lifecycle::last_lifecycle_warnings()` to see where this warning was
+#> generated.
 agdb_60s
 #> # A tibble: 1,500 × 4
 #>    timestamp           axis1 axis2 axis3
@@ -220,8 +241,7 @@ agdb_60s %>% apply_choi()
 
 ### References
 
-<div id="refs" class="references csl-bib-body hanging-indent"
-entry-spacing="0">
+<div id="refs" class="references csl-bib-body hanging-indent">
 
 <div id="ref-Choi:2011aa" class="csl-entry">
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,10 +1,17 @@
 ## Test environments
-* local R installation, R 4.0.0
-* ubuntu 16.04 (on travis-ci), R 4.0.0
-* win-builder (devel)
+* local: macOS 15.7 (aarch64), R 4.6.0
+* GitHub Actions:
+  * macos-latest, R release
+  * windows-latest, R release
+  * ubuntu-latest, R devel
+  * ubuntu-latest, R release
+  * ubuntu-latest, R oldrel-1
+* win-builder: R devel, R release
 
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
+0 errors | 0 warnings | 0 notes
 
-* This is a new release.
+## Notes for CRAN
+
+This is the first CRAN submission of `actigraph.sleepr`.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -15,3 +15,10 @@
 ## Notes for CRAN
 
 This is the first CRAN submission of `actigraph.sleepr`.
+
+The "Possibly misspelled words in DESCRIPTION" check flags the following terms,
+which are intentional:
+
+* Choi, Kripke, Sadeh, Troiano — author surnames of the cited algorithms
+  (Choi 2011, Cole-Kripke 1992, Sadeh 1994, Troiano 2008).
+* agd — the file extension used by ActiGraph devices for activity count exports.

--- a/man/actigraph.sleepr.Rd
+++ b/man/actigraph.sleepr.Rd
@@ -25,4 +25,9 @@ Useful links:
 \author{
 \strong{Maintainer}: Desislava Petkova \email{desislavka@gmail.com}
 
+Authors:
+\itemize{
+  \item Desislava Petkova \email{desislavka@gmail.com}
+}
+
 }

--- a/man/impute_epochs.Rd
+++ b/man/impute_epochs.Rd
@@ -27,5 +27,5 @@ gtxplus1day \%>\%
   impute_epochs(axis1)
 }
 \seealso{
-\code{\link[zoo:na.approx]{zoo::na.spline()}}, \code{\link[zoo:na.trim]{zoo::na.trim()}}
+\code{\link[zoo:na.spline]{zoo::na.spline()}}, \code{\link[zoo:na.trim]{zoo::na.trim()}}
 }

--- a/man/read_agd.Rd
+++ b/man/read_agd.Rd
@@ -39,8 +39,9 @@ list.files(path, pattern = "*.agd", full.names = TRUE) \%>\%
   map_dfr(read_agd, .id = ".filename")
 }
 \references{
-The AGD file format is described in the ActiLife 6 Manual.
-\url{https://actigraphcorp.com/support/manuals/actilife-6-manual/}
+The AGD file format is described in the ActiLife 6 User's
+Manual by the ActiGraph Software Department, 04/03/2012
+(Document SFT12DOC13, Revision A).
 }
 \seealso{
 \code{\link[=read_agd_raw]{read_agd_raw()}}

--- a/man/read_agd_raw.Rd
+++ b/man/read_agd_raw.Rd
@@ -35,7 +35,7 @@ str(read_agd_raw(file))
 }
 \references{
 ActiLife 6 User's Manual by the ActiGraph Software
-Department. 04/03/2012.
+Department, 04/03/2012 (Document SFT12DOC13, Revision A).
 
 \code{covertagd}: R package for converting agd files
 from ActiGraph into data.frames.

--- a/vignettes/detect-nonwear.Rmd
+++ b/vignettes/detect-nonwear.Rmd
@@ -10,8 +10,7 @@ vignette: >
 ```{r setup, echo = FALSE}
 knitr::opts_chunk$set(
   echo = TRUE, warning = FALSE, message = FALSE, collapse = TRUE,
-  comment = "#>", out.width = "75%", fig.asp = 1 / 1.6, fig.width = 5,
-  dpi = 600, fig.retina = NULL
+  comment = "#>", out.width = "75%", fig.asp = 1 / 1.6, fig.width = 5
 )
 pckg <- c("actigraph.sleepr", "dplyr", "lubridate", "ggplot2")
 inst <- suppressMessages(lapply(pckg, library, character.only = TRUE))

--- a/vignettes/detect-sleep.Rmd
+++ b/vignettes/detect-sleep.Rmd
@@ -10,8 +10,7 @@ vignette: >
 ```{r setup, echo = FALSE}
 knitr::opts_chunk$set(
   echo = TRUE, warning = FALSE, message = FALSE, collapse = TRUE,
-  comment = "#>", out.width = "75%", fig.asp = 1 / 1.6, fig.width = 5,
-  dpi = 600, fig.retina = NULL
+  comment = "#>", out.width = "75%", fig.asp = 1 / 1.6, fig.width = 5
 )
 pckg <- c("actigraph.sleepr", "dplyr", "tidyr", "lubridate", "ggplot2")
 inst <- suppressMessages(lapply(pckg, library, character.only = TRUE))
@@ -32,7 +31,7 @@ file_10s <- system.file(
 
 ### Read AGD file(s)
 
-An AGD file is an SQLite database file exported by an ActiGraph device, which contains five tables: settings, data, sleep, awakenings and filters. The sleep and awakenings tables are empty unless the ActiLife tool has been used to analyze the activity counts to detect sleep. See the [ActiLife 6 User manual](https://actigraphcorp.com/support/manuals/actilife-6-manual/).
+An AGD file is an SQLite database file exported by an ActiGraph device, which contains five tables: settings, data, sleep, awakenings and filters. The sleep and awakenings tables are empty unless the ActiLife tool has been used to analyze the activity counts to detect sleep. See the ActiLife 6 User's Manual by the ActiGraph Software Department, 04/03/2012 (Document SFT12DOC13, Revision A).
 
 We can load all five tables as a list using the `read_agd_raw` function.
 


### PR DESCRIPTION
## Summary

Prepare `actigraph.sleepr` for first CRAN submission.

- Bump version `0.2.0` → `0.3.0`
- Remove incorrect `NeedsCompilation: no` from DESCRIPTION
- Remove base R package `tools` from `Suggests`
- Refresh `cran-comments.md` with current test environments
- Update `NEWS.md` for the 0.3.0 release
- Regenerate documentation with roxygen2 8.0.0

## Test plan

- [x] `devtools::check()` clean (0 errors / 0 warnings / 0 notes)
- [x] `devtools::test()` clean (0 fail / 57 pass)
- [ ] CI matrix passes on macOS / Windows / Ubuntu (devel/release/oldrel-1)
- [ ] `devtools::check_win_devel()` clean
- [ ] `devtools::check_win_release()` clean

The win-builder checks are the next step after CI is green. Final
submission via `devtools::release()` will be a separate session.
